### PR TITLE
Fix extra spaces in prompts

### DIFF
--- a/pywhyllm/suggesters/identification_suggester.py
+++ b/pywhyllm/suggesters/identification_suggester.py
@@ -4,7 +4,7 @@ from .model_suggester import ModelSuggester
 import guidance
 from guidance import system, user, assistant, gen
 import re
-
+import inspect
 
 class IdentificationSuggester(IdentifierProtocol):
     CONTEXT: str = """causal mechanisms"""
@@ -199,14 +199,15 @@ class IdentificationSuggester(IdentifierProtocol):
             try:
                 lm = self.llm
                 with system():
-                    lm += f"""You are an expert in {domain_expertise} and are studying {analysis_context}. You are using your 
+                    prompt_str = f"""You are an expert in {domain_expertise} and are studying {analysis_context}. You are using your 
                 knowledge to help build a causal model that contains all the assumptions about the factors that are directly 
                 influencing athe {outcome}. Where a causal model is a conceptual model that describes the causal mechanisms 
                 of a system. You will do this by by answering questions about cause and effect and using your domain knowledge 
                 in {domain_expertise}. Follow the next two steps, and complete the first one before moving on to the second:"""
+                    lm += inspect.cleandoc(prompt_str)
 
                 with user():
-                    lm += f"""(1) From your perspective as an expert in {domain_expertise}, think step by step as you consider the factors 
+                    prompt_str = f"""(1) From your perspective as an expert in {domain_expertise}, think step by step as you consider the factors 
                 that may interact between the {treatment} and the {outcome}. Use your knowledge as an expert in 
                 {domain_expertise} to describe the mediators, if there are any at all, between {treatment} and the 
                 {outcome}. Be concise and keep your thinking within two paragraphs. Then provide your step by step chain 
@@ -223,6 +224,7 @@ class IdentificationSuggester(IdentifierProtocol):
                   the tags <mediating_factor>factor_name</mediating_factor>. Where factor_name is one of the items within the 
                   factor_names list. If a factor does not have a high likelihood of mediating, then do not wrap the factor with 
                   any tags. Your step by step answer as an in {domain_expertise}:"""
+                    lm += inspect.cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")
@@ -314,15 +316,16 @@ class IdentificationSuggester(IdentifierProtocol):
             try:
                 lm = self.llm
                 with system():
-                    lm += f"""You are an expert in {domain_expertise} and are studying {analysis_context}. 
+                    prompt_str = f"""You are an expert in {domain_expertise} and are studying {analysis_context}. 
                         You are using your knowledge to help build a causal model that contains all the assumptions about the factors 
                         that are directly influencing the {outcome}. Where a causal model is a conceptual model that describes the 
                         causal mechanisms of a system. You will do this by by answering questions about cause and effect and using 
                         your domain knowledge in {domain_expertise}. Follow the next two steps, and complete the first one before 
                         moving on to the second:"""
+                    lm += inspect.cleandoc(prompt_str)
 
                 with user():
-                    lm += f"""(1) From your perspective as an expert in {domain_expertise}, think step by step 
+                    prompt_str = f"""(1) From your perspective as an expert in {domain_expertise}, think step by step 
                        as you consider the factors that may interact with the {treatment} and do not interact with {outcome}. 
                        Use your knowlegde as an expert in {domain_expertise} to describe the instrumental variable(s), 
                        if there are any at all, that both has/have a high likelihood of influecing and causing the {treatment} and 
@@ -341,6 +344,7 @@ class IdentificationSuggester(IdentifierProtocol):
                        Where factor_name is one of the items within the factor_names list. If a factor does not have a high 
                        likelihood of being an instrumental variable, then do not wrap the factor with any tags. Your step by step 
                        answer as an in {domain_expertise}:"""
+                    lm += inspect.cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 

--- a/pywhyllm/suggesters/identification_suggester.py
+++ b/pywhyllm/suggesters/identification_suggester.py
@@ -4,7 +4,7 @@ from .model_suggester import ModelSuggester
 import guidance
 from guidance import system, user, assistant, gen
 import re
-import inspect
+from inspect import cleandoc
 
 class IdentificationSuggester(IdentifierProtocol):
     CONTEXT: str = """causal mechanisms"""
@@ -204,7 +204,7 @@ class IdentificationSuggester(IdentifierProtocol):
                 influencing athe {outcome}. Where a causal model is a conceptual model that describes the causal mechanisms 
                 of a system. You will do this by by answering questions about cause and effect and using your domain knowledge 
                 in {domain_expertise}. Follow the next two steps, and complete the first one before moving on to the second:"""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
 
                 with user():
                     prompt_str = f"""(1) From your perspective as an expert in {domain_expertise}, think step by step as you consider the factors 
@@ -224,7 +224,7 @@ class IdentificationSuggester(IdentifierProtocol):
                   the tags <mediating_factor>factor_name</mediating_factor>. Where factor_name is one of the items within the 
                   factor_names list. If a factor does not have a high likelihood of mediating, then do not wrap the factor with 
                   any tags. Your step by step answer as an in {domain_expertise}:"""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")
@@ -322,7 +322,7 @@ class IdentificationSuggester(IdentifierProtocol):
                         causal mechanisms of a system. You will do this by by answering questions about cause and effect and using 
                         your domain knowledge in {domain_expertise}. Follow the next two steps, and complete the first one before 
                         moving on to the second:"""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
 
                 with user():
                     prompt_str = f"""(1) From your perspective as an expert in {domain_expertise}, think step by step 
@@ -344,7 +344,7 @@ class IdentificationSuggester(IdentifierProtocol):
                        Where factor_name is one of the items within the factor_names list. If a factor does not have a high 
                        likelihood of being an instrumental variable, then do not wrap the factor with any tags. Your step by step 
                        answer as an in {domain_expertise}:"""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 

--- a/pywhyllm/suggesters/model_suggester.py
+++ b/pywhyllm/suggesters/model_suggester.py
@@ -5,7 +5,7 @@ import guidance
 from guidance import system, user, assistant, gen
 from ..helpers import RelationshipStrategy
 import re
-import inspect
+from inspect import cleandoc
 
 class ModelSuggester(ModelerProtocol):
     CONTEXT: str = """causal mechanisms"""
@@ -39,7 +39,7 @@ class ModelSuggester(ModelerProtocol):
                     such factors? Think about this in a step by step manner and recommend {n_experts} expertises and 
                     provide each one wrapped within the tags, <domain_expertise></domain_expertise>, along with the 
                     reasoning and explanation wrapped between the tags <explanation></explanation>."""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -82,7 +82,7 @@ class ModelSuggester(ModelerProtocol):
                     about this in a step by step manner and recommend {n_experts} domain experts and provide each one 
                     wrapped within the tags, <domain_expert></domain_expert>, along with the reasoning and explanation 
                     wrapped between the tags <explanation></explanation>."""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -126,7 +126,7 @@ class ModelSuggester(ModelerProtocol):
                 this in a step by step manner and recommend {n_stakeholders} stakeholders. Then provide each useful stakeholder 
                 wrapped within the tags, <stakeholder></stakeholder>, along with the reasoning and explanation wrapped between the tags
                 <explanation></explanation>."""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -212,7 +212,7 @@ class ModelSuggester(ModelerProtocol):
                     analysis_context}. Where a causal model is a conceptual model that describes the causal mechanisms of a 
                     system. You
                     will do this by answering questions about cause and effect and using your domain knowledge in {domain_expertise}."""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
                 with user():
                     prompt_str = f"""Follow the next two steps, and complete the first one before moving on to the second: (1) 
                                 From your perspective as an 
@@ -234,7 +234,7 @@ class ModelSuggester(ModelerProtocol):
                 <confounding_factor>factor_name</confounding_factor> where 
                 factor_name is one of the items within the factor_names list. If a factor does not have a high likelihood of directly 
                 confounding, then do not wrap the factor with any tags."""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -311,7 +311,7 @@ class ModelSuggester(ModelerProtocol):
 {factor}, 
                             then do not wrap the factor with any tags. Your answer as an expert in 
 {domain_expertise}:"""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")
@@ -383,7 +383,7 @@ class ModelSuggester(ModelerProtocol):
                             factor_names list. If a factor does not have a high likelihood of directly influencing and causing the {
                     factor}, then do not wrap the factor with any tags. Your answer as an expert in 
                 {domain_expertise}:"""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -424,7 +424,7 @@ class ModelSuggester(ModelerProtocol):
                             mechanisms of a system. You will do this by by answering questions about cause and effect and using your 
                             domain 
                             knowledge as an expert in {domain_expertise}."""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
                 with user():
                     prompt_str = f"""From your perspective as an expert in {domain_expertise}, which of the following is 
                                     most likely true? (A) {factor_a} affects {factor_b}; {factor_a} has a high likelihood of directly 
@@ -436,7 +436,7 @@ class ModelSuggester(ModelerProtocol):
                 you reach a conclusion, wrap your answer within the tags <answer></answer>. If you are done thinking, provide your 
                 answer wrapped within the tags <answer></answer>. e.g. <answer>A</answer>, <answer>B</answer>, or <answer>C</answer>. 
                 Your answer as an expert in {domain_expertise}:"""
-                    lm += inspect.cleandoc(prompt_str)
+                    lm += cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")

--- a/pywhyllm/suggesters/model_suggester.py
+++ b/pywhyllm/suggesters/model_suggester.py
@@ -5,7 +5,7 @@ import guidance
 from guidance import system, user, assistant, gen
 from ..helpers import RelationshipStrategy
 import re
-
+import inspect
 
 class ModelSuggester(ModelerProtocol):
     CONTEXT: str = """causal mechanisms"""
@@ -32,13 +32,14 @@ class ModelSuggester(ModelerProtocol):
                 with system():
                     lm += f"""You are a helpful assistant for recommending useful domain expertises."""
                 with user():
-                    lm += f"""What domain expertises have the knowledge and experience needed to identify causal 
+                    prompt_str = f"""What domain expertises have the knowledge and experience needed to identify causal 
                     relationships and causal influences between the {analysis_context}? What domain expertises are needed 
                     to work with and reason about the causal influence between {factors_list}? What domain expertises 
                     have the knowledge and experience to reason and answer questions about influence and cause between 
                     such factors? Think about this in a step by step manner and recommend {n_experts} expertises and 
                     provide each one wrapped within the tags, <domain_expertise></domain_expertise>, along with the 
                     reasoning and explanation wrapped between the tags <explanation></explanation>."""
+                    lm += inspect.cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -74,13 +75,14 @@ class ModelSuggester(ModelerProtocol):
                 with system():
                     lm += f"""You are a helpful assistant for recommending useful domain experts."""
                 with user():
-                    lm += f"""What domain experts have the knowledge and experience needed to identify causal relationships 
+                    prompt_str = f"""What domain experts have the knowledge and experience needed to identify causal relationships 
                     and causal influences between the {analysis_context}? What experts are needed to work with and 
                     reason about the causal influence between {factors_list}? What domain experts have the knowledge 
                     and experience to reason and answer questions about influence and cause between such factors? Think 
                     about this in a step by step manner and recommend {n_experts} domain experts and provide each one 
                     wrapped within the tags, <domain_expert></domain_expert>, along with the reasoning and explanation 
                     wrapped between the tags <explanation></explanation>."""
+                    lm += inspect.cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -118,12 +120,13 @@ class ModelSuggester(ModelerProtocol):
                     lm += "You are a helpful assistant for recommending useful primary and secondary stakeholders."
 
                 with user():
-                    lm += f"""What stakeholders have knowledge and experience in and about {analysis_context}? 
-                                    What stakeholders can work best with and reason well about the causal influence between 
+                    prompt_str = f"""What stakeholders have knowledge and experience in and about {analysis_context}? 
+                What stakeholders can work best with and reason well about the causal influence between 
                 {factors_list}? What stakeholders have the knowledge and experience useful to reason within this context? Think about 
                 this in a step by step manner and recommend {n_stakeholders} stakeholders. Then provide each useful stakeholder 
                 wrapped within the tags, <stakeholder></stakeholder>, along with the reasoning and explanation wrapped between the tags
                 <explanation></explanation>."""
+                    lm += inspect.cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -204,13 +207,14 @@ class ModelSuggester(ModelerProtocol):
             try:
                 lm = self.llm
                 with system():
-                    lm += f"""You are an expert in {domain_expertise} and are studying {analysis_context}.
-                You are using your knowledge to help build a causal model that contains all the assumptions about {
+                    prompt_str = f"""You are an expert in {domain_expertise} and are studying {analysis_context}.
+                    You are using your knowledge to help build a causal model that contains all the assumptions about {
                     analysis_context}. Where a causal model is a conceptual model that describes the causal mechanisms of a 
-                        system. You
-                will do this by by answering questions about cause and effect and using your domain knowledge in {domain_expertise}."""
+                    system. You
+                    will do this by answering questions about cause and effect and using your domain knowledge in {domain_expertise}."""
+                    lm += inspect.cleandoc(prompt_str)
                 with user():
-                    lm += f"""Follow the next two steps, and complete the first one before moving on to the second: (1) 
+                    prompt_str = f"""Follow the next two steps, and complete the first one before moving on to the second: (1) 
                                 From your perspective as an 
                 expert in {domain_expertise}, think step by step as you consider the factors that may interact between the {treatment} 
                 and the {outcome}. Use your knowlegde as an expert in {domain_expertise} to describe the confounders, if there are any 
@@ -230,6 +234,7 @@ class ModelSuggester(ModelerProtocol):
                 <confounding_factor>factor_name</confounding_factor> where 
                 factor_name is one of the items within the factor_names list. If a factor does not have a high likelihood of directly 
                 confounding, then do not wrap the factor with any tags."""
+                    lm += inspect.cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -284,7 +289,7 @@ class ModelSuggester(ModelerProtocol):
                     lm += f"""You are an expert in {domain_expertise} and are studying {analysis_context}"""
 
                 with user():
-                    lm += f"""You are using your knowledge to help build a causal model that 
+                    prompt_str = f"""You are using your knowledge to help build a causal model that 
                             contains all the assumptions about the factors that are directly influencing 
                             and causing the {factor}. Where a causal model is a conceptual model that describes the 
                             causal mechanisms of a system. You will do this by by answering questions about cause and 
@@ -306,6 +311,7 @@ class ModelSuggester(ModelerProtocol):
 {factor}, 
                             then do not wrap the factor with any tags. Your answer as an expert in 
 {domain_expertise}:"""
+                    lm += inspect.cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")
@@ -349,7 +355,7 @@ class ModelSuggester(ModelerProtocol):
                 with system():
                     lm += f"""You are an expert in {domain_expertise} and are studying {analysis_context}"""
                 with user():
-                    lm += f"""You are using your knowledge to help build a causal model that 
+                    prompt_str = f"""You are using your knowledge to help build a causal model that 
                             contains all the assumptions about the factors that are directly influencing and causing the {factor}. 
                             Where a 
                             causal model is a conceptual model that describes the causal mechanisms of a system. You will do this by by 
@@ -377,7 +383,7 @@ class ModelSuggester(ModelerProtocol):
                             factor_names list. If a factor does not have a high likelihood of directly influencing and causing the {
                     factor}, then do not wrap the factor with any tags. Your answer as an expert in 
                 {domain_expertise}:"""
-
+                    lm += inspect.cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -410,7 +416,7 @@ class ModelSuggester(ModelerProtocol):
             try:
                 lm = self.llm
                 with system():
-                    lm += f"""You are an expert in {domain_expertise} and are 
+                    prompt_str = f"""You are an expert in {domain_expertise} and are 
                             studying {analysis_context}. You are using your knowledge to help build a causal model that contains 
                             all the 
                             assumptions about {analysis_context}. Where a causal model is a conceptual model that describes the 
@@ -418,8 +424,9 @@ class ModelSuggester(ModelerProtocol):
                             mechanisms of a system. You will do this by by answering questions about cause and effect and using your 
                             domain 
                             knowledge as an expert in {domain_expertise}."""
+                    lm += inspect.cleandoc(prompt_str)
                 with user():
-                    lm += f"""From your perspective as an expert in {domain_expertise}, which of the following is 
+                    prompt_str = f"""From your perspective as an expert in {domain_expertise}, which of the following is 
                                     most likely true? (A) {factor_a} affects {factor_b}; {factor_a} has a high likelihood of directly 
                                     influencing {factor_b}; and {factor_a} causes {factor_b}. (B) {factor_b} affects {factor_a}; 
                 {factor_b} has a high likelihood of directly influencing {factor_a}; and {factor_b} causes {factor_a}. (C) Neither A 
@@ -429,6 +436,7 @@ class ModelSuggester(ModelerProtocol):
                 you reach a conclusion, wrap your answer within the tags <answer></answer>. If you are done thinking, provide your 
                 answer wrapped within the tags <answer></answer>. e.g. <answer>A</answer>, <answer>B</answer>, or <answer>C</answer>. 
                 Your answer as an expert in {domain_expertise}:"""
+                    lm += inspect.cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")

--- a/pywhyllm/suggesters/simple_identification_suggester.py
+++ b/pywhyllm/suggesters/simple_identification_suggester.py
@@ -1,7 +1,7 @@
 import guidance
 from guidance import system, user, assistant, gen
 import re
-
+from inspect import cleandoc
 
 class SimpleIdentificationSuggester:
 
@@ -16,9 +16,10 @@ class SimpleIdentificationSuggester:
             lm += "You are a helpful assistant for causal reasoning."
 
         with user():
-            lm += f"""Which factors in {factors} might be valid instrumental variables for identifying the effect of {treatment} on {outcome}?
+            prompt_str = f"""Which factors in {factors} might be valid instrumental variables for identifying the effect of {treatment} on {outcome}?
 
             List the factors that are possible instrumental variables in <iv> </iv> tags."""
+            lm += cleandoc(prompt_str)
         with assistant():
             lm += gen("iv")
 
@@ -33,10 +34,11 @@ class SimpleIdentificationSuggester:
             lm += "You are a helpful assistant for causal reasoning."
 
         with user():
-            lm += f"""Which set or subset of factors in {factors} might satisfy the backdoor criteria for identifying the effect of {treatment} on {outcome}?
+            prompt_str = f"""Which set or subset of factors in {factors} might satisfy the backdoor criteria for identifying the effect of {treatment} on {outcome}?
 
             List the factors satisfying the backdoor criteria enclosing the name of each factor in <backdoor> </backdoor> tags.
             """
+            lm += cleandoc(prompt_str)
         with assistant():
             lm += gen("backdoors")
 
@@ -51,10 +53,11 @@ class SimpleIdentificationSuggester:
             lm += "You are a helpful assistant for causal reasoning."
 
         with user():
-            lm += f"""Which set or subset of factors in {factors} might satisfy the frontdoor criteria for identifying the effect of {treatment} on {outcome}?
+            prompt_str = f"""Which set or subset of factors in {factors} might satisfy the frontdoor criteria for identifying the effect of {treatment} on {outcome}?
 
             List the factors satisfying the frontdoor criteria enclosing the name of each factor in <frontdoor> </frontdoor> tags.
             """
+            lm += cleandoc(prompt_str)
         with assistant():
             lm += gen("frontdoors")
 

--- a/pywhyllm/suggesters/simple_model_suggester.py
+++ b/pywhyllm/suggesters/simple_model_suggester.py
@@ -3,7 +3,7 @@ import guidance
 import re
 import itertools
 from guidance import system, user, assistant, gen
-
+from inspect import cleandoc
 
 class SimpleModelSuggester:
     """
@@ -43,8 +43,9 @@ class SimpleModelSuggester:
             lm += "You are a helpful assistant for causal reasoning."
 
         with user():
-            lm += f"""Which cause-and-effect-relationship is more likely? Provide reasoning and give your final answer (A, B, or C) in <answer> </answer> tags with the letter only and no whitespaces.
+            prompt_str = f"""Which cause-and-effect-relationship is more likely? Provide reasoning and give your final answer (A, B, or C) in <answer> </answer> tags with the letter only and no whitespaces.
             A. {variable1} causes {variable2} B. {variable2} causes {variable1} C. neither {variable1} nor {variable2} cause each other."""
+            lm += cleandoc(prompt_str)
 
         with assistant():
             lm += gen("description")
@@ -110,12 +111,13 @@ class SimpleModelSuggester:
             lm += "You are a helpful assistant for causal reasoning."
 
         with user():
-            lm += f"""What latent confounding factors might influence the relationship between {treatment} and {outcome}?
+            prompt_str = f"""What latent confounding factors might influence the relationship between {treatment} and {outcome}?
 
             We have already considered the following factors {variables}.  Please do not repeat them.
 
             List the confounding factors between {treatment} and {outcome} enclosing the name of each factor in <conf> </conf> tags.
             """
+            lm += cleandoc(prompt_str)
         with assistant():
             lm += gen("latents")
 

--- a/pywhyllm/suggesters/tuebingen_model_suggester.py
+++ b/pywhyllm/suggesters/tuebingen_model_suggester.py
@@ -120,17 +120,17 @@ class TuebingenModelSuggester(ModelSuggester):
             query["user"] = cleandoc(user_prompt)
 
             if ask_reference:
-                query["user"] += " " # cleandoc removes leading whitespace, so need to add separately
                 user_prompt = f"""Then provide two research papers that support your description.
                 Let's think step-by-step to make sure that we have a proper and clear description. Then provide your final 
-                answer within the tags, <description></description>, and each research paper within the tags <reference></reference>."""
-                query["user"] += cleandoc(user_prompt)
+                answer within the tags, <description></description>, and each research paper within the tags <reference></reference>.""" 
+                # cleandoc removes leading whitespace, so need to add separately
+                query["user"] += " " + cleandoc(user_prompt)
 
             else:
-                query["user"] += "\n" # cleandoc removes leading whitespace, so need to add separately
                 user_prompt = f"""Let's think step-by-step to make sure that we have a proper and clear description. Then provide your final 
                 answer within the tags, <description></description>."""
-                query["user"] += cleandoc(user_prompt)
+                # cleandoc removes leading whitespace, so need to add separately
+                query["user"] += "\n" + cleandoc(user_prompt)
 
         else:
             sys_prompt = f"""You are a helpful assistant for writing concise and peer-reviewed descriptions. Your goal 
@@ -141,17 +141,16 @@ class TuebingenModelSuggester(ModelSuggester):
             query["user"] = cleandoc(user_prompt)
 
             if ask_reference:
-                query["user"] += "\n" # cleandoc removes leading whitespace, so need to add separately
                 user_prompt = f"""Then provide two research papers that support your description.
                         Let's think step-by-step to make sure that we have a proper and clear description. Then provide 
                         your final answer within the tags, <description></description>, and each research paper within the 
                         tags <paper></paper>."""
-                query["user"] += cleandoc(user_prompt)
+                # cleandoc removes leading whitespace, so need to add separately
+                query["user"] += "\n" + cleandoc(user_prompt)
             else:
-                query["user"] += "\n" # cleandoc removes leading whitespace, so need to add separately
                 user_prompt = f"""Let's think step-by-step to make sure that we have a proper and clear description. Then provide 
                         your final answer within the tags, <description></description>."""
-                query["user"] += cleandoc(user_prompt)
+                query["user"] += "\n" + cleandoc(user_prompt)
         return query
 
     def suggest_relationship(
@@ -258,10 +257,10 @@ class TuebingenModelSuggester(ModelSuggester):
                 if use_description:
                     user_prompt = f"""can changing {variable_a}, where {description_a}, change {variable_b}, where 
     {description_b}? Answer Yes or No."""
-                    query["user"] += cleandoc(user_prompt)
+                    query["user"] = cleandoc(user_prompt)
                 else:
                     user_prompt = f"""can changing {variable_a} change {variable_b}? Answer Yes or No."""
-                    query["user"] += cleandoc(user_prompt)
+                    query["user"] = cleandoc(user_prompt)
 
                 if ask_reference:
                     user_prompt = f"""At each step, each expert include a reference to a research paper that supports 

--- a/pywhyllm/suggesters/tuebingen_model_suggester.py
+++ b/pywhyllm/suggesters/tuebingen_model_suggester.py
@@ -234,15 +234,17 @@ class TuebingenModelSuggester(ModelSuggester):
         query = {}
 
         if use_domain is not None:
-            query["system"] = f"""You are a helpful assistant on causal reasoning and {use_domain}. Your goal is to answer 
+            sys_prompt = f"""You are a helpful assistant on causal reasoning and {use_domain}. Your goal is to answer 
             questions about cause and effect in a factual and concise way."""
+            query["system"] = cleandoc(sys_prompt)
         else:
-            query["system"] = f"""You are a helpful assistant on causal reasoning. Your goal is to answer questions 
+            sys_prompt = f"""You are a helpful assistant on causal reasoning. Your goal is to answer questions 
             about cause and effect in a factual and concise way."""
+            query["system"] = cleandoc(sys_prompt)
 
         if use_strategy is not None:
             if use_strategy == Strategy.ToT_Single:
-                query["user"] = f"""There is a council of three different experts answering this question.
+                user_prompt = f"""There is a council of three different experts answering this question.
                     Each of the three expert will write down 1 step of their thinking, and share it with the council. 
                     Then all experts will go on to the next step, etc.
                     All experts in the council are arguing to arrive to a true and factual answer. Their goal is to arrive 
@@ -251,36 +253,43 @@ class TuebingenModelSuggester(ModelSuggester):
                     If any expert realises their argument is wrong at any point, then they will adjust their argument to 
                     be factual and logical.
                     The question is """
+                query["user"] = cleandoc(user_prompt)
 
                 if use_description:
-                    query["user"] = f"""can changing {variable_a}, where {description_a}, change {variable_b}, where 
+                    user_prompt = f"""can changing {variable_a}, where {description_a}, change {variable_b}, where 
     {description_b}? Answer Yes or No."""
+                    query["user"] += cleandoc(user_prompt)
                 else:
-                    query["user"] = f"""can changing {variable_a} change {variable_b}? Answer Yes or No."""
+                    user_prompt = f"""can changing {variable_a} change {variable_b}? Answer Yes or No."""
+                    query["user"] += cleandoc(user_prompt)
 
                 if ask_reference:
-                    query["user"] += f"""At each step, each expert include a reference to a research paper that supports 
-                    their argument. They will provide a one sentence summary of the paper and how it supports their argument. 
+                    user_prompt = f"""At each step, each expert include a reference to a research paper that supports 
+                        their argument. They will provide a one sentence summary of the paper and how it supports their argument. 
                         Then they will answer whether a change in {variable_a} changes {variable_b}. Answer Yes or No.
                         When consensus is reached, thinking carefully and factually, explain the council's answer. Provide 
                         the answer within the tags, <answer>Yes/No</answer>, and the most influential reference within 
                         the tags <reference>Author, Title, Year of publication</reference>.
                         \n\n\n----------------\n\n\n<answer>Yes</answer>\n<reference>Author, Title, Year of 
                         publication</reference>\n\n\n----------------\n\n\n<answer>No</answer>"""
+                    query["user"] += cleandoc(user_prompt)
                 else:
-                    query["user"] += """When consensus is reached, thinking carefully and factually, explain the council's answer. 
+                    user_prompt = """When consensus is reached, thinking carefully and factually, explain the council's answer. 
                     Provide the answer within the tags, <answer>Yes/No</answer>.
                         \n\n\n----------------\n\n\n<answer>Yes</answer>\n\n\n----------------\n\n\n<answer>No</answer>"""
+                    query["user"] += cleandoc(user_prompt)
 
             elif use_strategy == Strategy.CoT:
                 if use_description:
-                    query["user"] = f"""Can changing {variable_a}, where {description_a}, change {variable_b}, where 
-                    {description_b}? """
+                    user_prompt = f"""Can changing {variable_a}, where {description_a}, change {variable_b}, where 
+                    {description_b}?"""
+                    query["user"] = cleandoc(user_prompt)
                 else:
-                    query["user"] = f"""Can changing {variable_a} change {variable_b}?"""
+                    user_prompt = f"""Can changing {variable_a} change {variable_b}?"""
+                    query["user"] = cleandoc(user_prompt)
 
                 if ask_reference:
-                    query["user"] += f"""What are three research papers that discuss each of these variables? What do they 
+                    user_prompt = f"""What are three research papers that discuss each of these variables? What do they 
                     say about the relationship they may or may not have? You are to provide the paper title and a one 
                     sentence summary each paper's argument. Then use those arguments as reference to answer whether a change 
                     in {variable_a} changes {variable_b}. Answer Yes or No.
@@ -289,33 +298,36 @@ class TuebingenModelSuggester(ModelSuggester):
                         <reference>Author, Title, Year of publication</reference>. 
                         \n\n\n----------------\n\n\n<answer>Yes</answer>\n<reference>Author, Title, 
                         Year of publication</reference>\n\n\n----------------\n\n\n<answer>No</answer> {{~/user}}"""
+                    query["user"] += cleandoc(user_prompt)
                 else:
-                    query["user"] += f"""Answer Yes or No. Within one sentence, you are to think step-by-step to make sure 
+                    user_prompt = f"""Answer Yes or No. Within one sentence, you are to think step-by-step to make sure 
                     that you have the right answer. Then provide your final answer within the tags, <answer>Yes/No</answer.
                         \n\n\n----------------\n\n\n<answer>Yes</answer>\n\n\n----------------\n\n\n<answer>No</answer>"""
+                    query["user"] += cleandoc(user_prompt)
 
             elif use_strategy == Strategy.Straight:
                 if use_description:
-                    query[
-                        "user"] = f"""Can changing {variable_a}, where {description_a}, change {variable_b}, where {description_b}? """
+                    user_prompt = f"""Can changing {variable_a}, where {description_a}, change {variable_b}, where {description_b}? """
+                    query["user"] = cleandoc(user_prompt)
                 else:
-                    query["user"] = f"""Can changing {variable_a} change {variable_b}?"""
+                    user_prompt = f"""Can changing {variable_a} change {variable_b}?"""
+                    query["user"] = cleandoc(user_prompt)
 
                 if ask_reference:
-                    query["user"] += f"""What are three research papers that discuss each of these variables? What do they 
+                    user_prompt = f"""What are three research papers that discuss each of these variables? What do they 
                     say about the relationship they may or may not have? You are to provide the paper title and a one 
                     sentence summary each paper's argument. Then use those arguments as reference to answer whether a 
                     change in {variable_a} changes {variable_b}. Answer Yes or No.
-                        Within one sentence, you are to think step-by-step to make sure that you have the right answer. 
-                        Provide your final answer within the tags, <answer>Yes/No</answer>, and your references within 
-                        the tags <reference>Author, Title, Year of publication</reference. 
-                        \n\n\n----------------\n\n\n<answer>Yes</answer>\n<reference>Author, Title, Year of publication</reference>\n\n\n----------------\n\n\n<answer>No</answer>"""
+                    Within one sentence, you are to think step-by-step to make sure that you have the right answer. 
+                    Provide your final answer within the tags, <answer>Yes/No</answer>, and your references within 
+                    the tags <reference>Author, Title, Year of publication</reference. 
+                    \n\n\n----------------\n\n\n<answer>Yes</answer>\n<reference>Author, Title, Year of publication</reference>\n\n\n----------------\n\n\n<answer>No</answer>"""
+                    query["user"] += cleandoc(user_prompt)
 
                 else:
-                    query["user"] += f"""Answer Yes or No. Within one sentence, you are to think step-by-step to make sure 
+                    user_prompt = f"""Answer Yes or No. Within one sentence, you are to think step-by-step to make sure 
                     that you have the right answer. Then provide your final answer within the tags, <answer>Yes/No</answer>.
                         \n\n\n----------------\n\n\nExample of output structure: <answer>Yes</answer>\n\n\n----------------\n\n\nExample of output structure: <answer>No</answer>"""
-        query["user"] = cleandoc(query["user"])
-        query["system"] = cleandoc(query["system"])
+                    query["user"] += cleandoc(user_prompt)
 
         return query

--- a/pywhyllm/suggesters/validation_suggester.py
+++ b/pywhyllm/suggesters/validation_suggester.py
@@ -1,5 +1,6 @@
 import itertools
 from typing import List, Tuple, Dict, Set
+from inspect import cleandoc
 from ..protocols import IdentifierProtocol
 from ..helpers import RelationshipStrategy, ModelType
 from ..prompts import prompts as ps
@@ -75,14 +76,15 @@ class ValidationSuggester(IdentifierProtocol):
                 lm = self.llm
 
                 with system():
-                    lm += f"""You are an expert in the {domain_expertise} and are 
+                    prompt_str = f"""You are an expert in the {domain_expertise} and are 
             studying the {analysis_context}. You are using your domain knowledge to help understand the negative 
             controls for a causal model that contains all the assumptions about the {analysis_context}. Where a causal 
             model is a conceptual model that describes the causal mechanisms of a system. You will do this by answering 
             questions about cause and effect using your domain knowledge in the {domain_expertise}."""
+                    lm += cleandoc(prompt_str)
 
                 with user():
-                    lm += f"""factor_names: {factors_list} From your perspective as an expert in the {domain_expertise}, what factor(s) from the list of factors, relevant to 
+                    prompt_str = f"""factor_names: {factors_list} From your perspective as an expert in the {domain_expertise}, what factor(s) from the list of factors, relevant to 
                              the {analysis_context}, should see zero treatment effect when changing the {treatment}? Which factor(s) 
                              from the list of factors, if any at all, relevant to the {analysis_context}, are negative controls on the 
                              causal mechanisms that affect the {outcome} when changing {treatment}? Using your domain knowledge, 
@@ -98,6 +100,7 @@ class ValidationSuggester(IdentifierProtocol):
                              is one of the items within the factor_names list. If a factor does not have a high likelihood of being a 
                              negative control relevant to the {analysis_context}, then do not wrap the factor with any tags. Provide 
                              your step by step answer as an expert in the {domain_expertise}:"""
+                    lm += cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")
@@ -175,12 +178,13 @@ class ValidationSuggester(IdentifierProtocol):
             try:
                 lm = self.llm
                 with system():
-                    lm += f"""You are an expert in the {domain_expertise} and are studying the {analysis_context}. You are using your knowledge to help build a causal model that contains 
+                    prompt_str = f"""You are an expert in the {domain_expertise} and are studying the {analysis_context}. You are using your knowledge to help build a causal model that contains 
                                 all the assumptions about the {domain_expertise}. Where a causal model is a conceptual model that describes 
                                 the causal mechanisms of a system. You will do this by by answering questions about cause and effect and 
                                 using your domain knowledge in the {domain_expertise}."""
+                    lm += cleandoc(prompt_str)
                 with user():
-                    lm += f"""(1) From your perspective as an expert in the {domain_expertise}, think step by step as you consider the factors that may interact 
+                    prompt_str = f"""(1) From your perspective as an expert in the {domain_expertise}, think step by step as you consider the factors that may interact 
                                  between the {treatment} and the {outcome}. Use your knowledge as an expert in the {domain_expertise} to 
                                  describe the confounders, if there are any at all, between the {treatment} and the {outcome}. Be concise 
                                  and keep your thinking within two paragraphs. Then provide your step by step chain of thoughts within the 
@@ -194,6 +198,7 @@ class ValidationSuggester(IdentifierProtocol):
                                  {treatment} and the {outcome}, within the tags <confounding_factor>factor_name</confounding_factor>. If a 
                                  factor does not have a high likelihood of directly confounding, then do not wrap the factor with any tags. 
                                  Your step by step answer as an expert in the {domain_expertise}:"""
+                    lm += cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")
@@ -240,10 +245,11 @@ class ValidationSuggester(IdentifierProtocol):
             try:
                 lm = self.llm
                 with system():
-                    lm += f"""You are a helpful causal assistant and expert in {domain_expertise}, 
+                    prompt_str = f"""You are a helpful causal assistant and expert in {domain_expertise}, 
                                 studying {analysis_context}. Task: identify factors causing {factor}."""
+                    lm += cleandoc(prompt_str)
                 with user():
-                    lm += f"""Steps: (1) 
+                    prompt_str = f"""Steps: (1) 
                                 Analyze potential factors [{factors_list}] for factors directly influencing/causing/affecting {
                     factor}. Is relationship direct? Ignore feedback mechanisms/factors not in list. Keep thoughts within 
                                 <thinking></thinking> tags. (2) Use prior thoughts to answer: how {factor} influenced/caused/affected by  [
@@ -251,6 +257,7 @@ class ValidationSuggester(IdentifierProtocol):
                                 factors highly likely directly influencing/causing/affecting {factor} in 
                                 <influencing_factor></influencing_factor> tags. No tags for low likelihood factors. Ignore feedback 
                                 mechanisms/factors not in list. Answer as {domain_expertise} expert."""
+                    lm += cleandoc(prompt_str)
                 with assistant():
                     lm += gen("output")
 
@@ -292,11 +299,12 @@ class ValidationSuggester(IdentifierProtocol):
                 lm = self.llm
 
                 with system():
-                    lm += f"""You are a helpful causal assistant and expert in {domain_expertise}, 
+                    prompt_str = f"""You are a helpful causal assistant and expert in {domain_expertise}, 
                                 studying {analysis_context}. Task: identify factors caused by {factor}."""
+                    lm += cleandoc(prompt_str)
 
                 with user():
-                    lm += f"""Steps: (
+                    prompt_str = f"""Steps: (
                                 1) Analyze potential factors [{factors_list}] for factors directly influenced/caused/affected by 
                                 {factor}. Is relationship direct? Ignore feedback mechanisms/factors not in list. Keep thoughts within 
                                 <thinking></thinking> tags. (2) Use prior thoughts to answer: how {factor} influences/causes/affects [{
@@ -304,6 +312,7 @@ class ValidationSuggester(IdentifierProtocol):
                                 factors highly likely directly influenced/caused/affected by {factor} in 
                                 <influenced_factor></influenced_factor> tags. No tags for low likelihood factors. Ignore feedback 
                                 mechanisms/factors not in list. Answer as {domain_expertise} expert."""
+                    lm += cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")
@@ -338,16 +347,18 @@ class ValidationSuggester(IdentifierProtocol):
                 lm = self.llm
 
                 with system():
-                    lm += f"""You are a helpful causal assistant, expert in {domain_expertise}, 
+                    prompt_str = f"""You are a helpful causal assistant, expert in {domain_expertise}, 
                                 studying {analysis_context}. Task: identify relationship between {factor_a} and {factor_b}."""
+                    lm += cleandoc(prompt_str)
 
                 with user():
-                    lm += f"""Steps: (1) Does {factor_a} influence/cause/affect {factor_b}? Is relationship direct? Does {factor_b} influence/cause/affect 
+                    prompt_str = f"""Steps: (1) Does {factor_a} influence/cause/affect {factor_b}? Is relationship direct? Does {factor_b} influence/cause/affect 
                                 {factor_a}? Is relationship direct? Ignore feedback mechanisms/factors not in list. Keep thoughts within 
                                 <thinking></thinking> tags. (2) Use prior thoughts to select likely answer: (A) {factor_a} influences {factor_b} (B) {
                     factor_b} influences {factor_a} (C) Neither. Wrap answer in <answer></answer>. e.g. <answer>A</answer>, 
                                 <answer>B</answer>, <answer>C</answer>. No tags for low likelihood factors. Ignore feedback 
                                 mechanisms/factors not in list. Answer as {domain_expertise} expert."""
+                    lm += cleandoc(prompt_str)
 
                 with assistant():
                     lm += gen("output")

--- a/pywhyllm/tests/model_suggester/data_providers/tuebingen_model_suggester_data_provider.py
+++ b/pywhyllm/tests/model_suggester/data_providers/tuebingen_model_suggester_data_provider.py
@@ -20,17 +20,17 @@ test_suggest_description_expected_result = ([
 test_suggest_onesided_relationship_a_cause_b_expected_result = 1
 test_suggest_onesided_relationship_a_not_cause_b_expected_result = 0
 test__build_description_program_no_context_no_reference_expected_result = {
-    'system': 'You are a helpful assistant for writing concise and peer-reviewed descriptions. Your goal \n            is to provide factual and succinct description of the given concept.',
-    'user': " Describe the concept of water.\n                    In one sentence, provide a factual and succinct description of water\n                        Let's think step-by-step to make sure that we have a proper and clear description. Then provide \n                        your final answer within the tags, <description></description>."}
+    'system': 'You are a helpful assistant for writing concise and peer-reviewed descriptions. Your goal \nis to provide factual and succinct description of the given concept.',
+    'user': "Describe the concept of water.\nIn one sentence, provide a factual and succinct description of water.\nLet's think step-by-step to make sure that we have a proper and clear description. Then provide \nyour final answer within the tags, <description></description>."}
 test__build_description_program_no_context_with_reference_expected_result = {
-    'system': 'You are a helpful assistant for writing concise and peer-reviewed descriptions. Your goal \n            is to provide factual and succinct description of the given concept.',
-    'user': ' Describe the concept of water.\n                    In one sentence, provide a factual and succinct description of water"\n                        Then provide two research papers that support your description.\n                        Let\'s think step-by-step to make sure that we have a proper and clear description. Then provide \n                        your final answer within the tags, <description></description>, and each research paper within the \n                        tags <paper></paper>.'}
+    'system': 'You are a helpful assistant for writing concise and peer-reviewed descriptions. Your goal \nis to provide factual and succinct description of the given concept.',
+    'user': 'Describe the concept of water.\nIn one sentence, provide a factual and succinct description of water.\nThen provide two research papers that support your description.\nLet\'s think step-by-step to make sure that we have a proper and clear description. Then provide \nyour final answer within the tags, <description></description>, and each research paper within the \ntags <paper></paper>.'}
 test__build_description_program_with_context_with_reference_expected_result = {
-    'system': 'You are a helpful assistant for writing concise and peer-reviewed descriptions. Your goal is \n            to provide factual and succinct descriptions related to the given concept and context.',
-    'user': "Using this context about the particular variable, describe the concept of water.\n            In one sentence, provide a factual and succinct description of waterThen provide two research papers that support your description.\n                Let's think step-by-step to make sure that we have a proper and clear description. Then provide your final \n                answer within the tags, <description></description>, and each research paper within the tags <reference></reference>."}
+    'system': 'You are a helpful assistant for writing concise and peer-reviewed descriptions. Your goal is \nto provide factual and succinct descriptions related to the given concept and context.',
+    'user': "Using this context about the particular variable, describe the concept of water.\nIn one sentence, provide a factual and succinct description of water. Then provide two research papers that support your description.\nLet's think step-by-step to make sure that we have a proper and clear description. Then provide your final \nanswer within the tags, <description></description>, and each research paper within the tags <reference></reference>."}
 test__build_description_program_with_context_no_reference_expected_result = {
-    'system': 'You are a helpful assistant for writing concise and peer-reviewed descriptions. Your goal is \n            to provide factual and succinct descriptions related to the given concept and context.',
-    'user': "Using this context about the particular variable, describe the concept of water.\n            In one sentence, provide a factual and succinct description of water\n                    Let's think step-by-step to make sure that we have a proper and clear description. Then provide your final \n                    answer within the tags, <description></description>."}
+    'system': 'You are a helpful assistant for writing concise and peer-reviewed descriptions. Your goal is \nto provide factual and succinct descriptions related to the given concept and context.',
+    'user': "Using this context about the particular variable, describe the concept of water.\nIn one sentence, provide a factual and succinct description of water.\nLet's think step-by-step to make sure that we have a proper and clear description. Then provide your final \nanswer within the tags, <description></description>."}
 test_suggest_relationship_a_cause_b_expected_result = (1,
                                                        [
                                                            'Popkin, Barry M., Kristen E. D\'Anci, and Irwin H. Rosenberg. "Water, hydration and health." Nutrition reviews 68.8 (2010): 439-458.'])
@@ -40,7 +40,7 @@ test_suggest_relationship_a_not_cause_b_expected_result = (0,
 test__build_relationship_program_expected_result = {
     'system': 'You are a helpful assistant on causal reasoning and biology. Your '
               'goal is to answer \n'
-              '            questions about cause and effect in a factual and '
+              'questions about cause and effect in a factual and '
               'concise way.',
     'user': 'can changing water intake change hydration level? Answer Yes or '
             'No.When consensus is reached, thinking carefully and factually, '

--- a/pywhyllm/tests/model_suggester/test_tuebingen_model_suggester.py
+++ b/pywhyllm/tests/model_suggester/test_tuebingen_model_suggester.py
@@ -48,7 +48,6 @@ class TestTuebingenModelSuggester(unittest.TestCase):
         assert result == test__build_description_program_with_context_no_reference_expected_result
         #Test with context, with reference
         result = modeler._build_description_program(variable, True, True)
-        print(result)
         assert result == test__build_description_program_with_context_with_reference_expected_result
 
     def test_suggest_relationship(self):

--- a/pywhyllm/tests/model_suggester/test_tuebingen_model_suggester.py
+++ b/pywhyllm/tests/model_suggester/test_tuebingen_model_suggester.py
@@ -48,6 +48,7 @@ class TestTuebingenModelSuggester(unittest.TestCase):
         assert result == test__build_description_program_with_context_no_reference_expected_result
         #Test with context, with reference
         result = modeler._build_description_program(variable, True, True)
+        print(result)
         assert result == test__build_description_program_with_context_with_reference_expected_result
 
     def test_suggest_relationship(self):


### PR DESCRIPTION
The prompts are specified as multi-line strings in Python. As a result, the final prompt input to LLM contains many additional spaces and tabs. 
This PR fixes the space issues.